### PR TITLE
Change build workflow trigger to main branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   test:
@@ -25,7 +25,7 @@ jobs:
         go-version: 1.14.x
     - name: Set up kubebuilder
       # TODO replace with ../pkg/.. when that's merged
-      uses: fluxcd/pkg/actions/kubebuilder@master
+      uses: fluxcd/pkg/actions/kubebuilder@v0.0.4
     - name: Run tests
       run: make test
       env:


### PR DESCRIPTION
The default branch is now `main`, so trigger builds from that branch.
Also: use a specific version of the action from fluxcd/pkg, to avoid
just getting the latest commit, whatever that is.